### PR TITLE
WIP build and deploy by GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build and Deploy GH pages
+
+on:
+  push:
+    branches:
+    - master     # Push events on master branch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js 12.7.0
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.7.0
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@master
+      env:
+        ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: docs
+        BUILD_SCRIPT: npm ci && npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 npm-debug.log
 node_modules
 src/json/
+docs/


### PR DESCRIPTION
## これはなに

GitHub Actions で build して gh-pages にデプロイするやつ

resolve: #6 ビルドをいい感じにする 

## 必要事項

- GitHub pages の参照先を master ブランチの `docs/` から gh-pages ブランチに
- `GITHUB_ACCESS_TOKEN` の登録
- このリポジトリで GitHub Actions が使用できるようになる

## メリット

- ビルド後のコードの差分に悩まされなくなる
- GitHub で完結

## もうちょっと

- Pull Request ごとに実行して、適当なホスティングにデプロイすればステージングにできそう