### PR TITLE
どうしても link をつけられない post があるので、リンクなしの見出しを許す

### DIFF
--- a/src/html/tag.pug
+++ b/src/html/tag.pug
@@ -13,7 +13,10 @@ block main
       each post, i in posts.reduce((memo, post) => post.tags.includes(title) ? memo.concat(post) : memo, [])
         .Article__item
           h4.Article__heading
-            a.Article__link(href=post.link)= post.title
+            if (post.link)
+              a.Article__link(href=post.link)= post.title
+            else
+              =post.title
 
           .Article__body!= post.body
 


### PR DESCRIPTION
#24 「おもしろ動画・音楽」でどうしてもリンクがつけられない項目があった。
リンクなしの見出しを使いたい。