### PR TITLE
ホームにページタイトルを設定

### DIFF
--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -5,14 +5,10 @@ html(lang=site.lang)
   head(prefix="og: http://ogp.me/ns#")
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover")
-    title
-      if isHome
-        =site.title
-      else
-        =`${isTag ? tag.title : title} - ${site.title}`
+    title=`${isTag ? tag.title : title} - ${site.title}`
     meta(name="description" content=site.description)
     meta(name="twitter:card" content="summary")
-    meta(property="og:title" content=isTag ? tag.title : (title || site.title))
+    meta(property="og:title" content=isTag ? tag.title : title)
     meta(property="og:type" content="website")
     meta(property="og:image" content=`${site.origin}/apple-touch-icon.png`)
     meta(property="og:url" content=`${site.origin}${page.url}`)

--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -5,10 +5,11 @@ html(lang=site.lang)
   head(prefix="og: http://ogp.me/ns#")
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover")
-    if isHome
-      title=`${site.title} - ${title}`
-    else
-      title=`${isTag ? tag.title : title} - ${site.title}`
+    title
+      if isHome
+        =`${site.title} - ${title}`
+      else
+        =`${isTag ? tag.title : title} - ${site.title}`
     meta(name="description" content=site.description)
     meta(name="twitter:card" content="summary")
     meta(property="og:title" content=isTag ? tag.title : title)

--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -5,7 +5,10 @@ html(lang=site.lang)
   head(prefix="og: http://ogp.me/ns#")
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover")
-    title=`${isTag ? tag.title : title} - ${site.title}`
+    if isHome
+      title=`${site.title} - ${title}`
+    else
+      title=`${isTag ? tag.title : title} - ${site.title}`
     meta(name="description" content=site.description)
     meta(name="twitter:card" content="summary")
     meta(property="og:title" content=isTag ? tag.title : title)

--- a/src/index.11tydata.json
+++ b/src/index.11tydata.json
@@ -1,3 +1,4 @@
 {
+  "title": "Webアクセシビリティの参考資料まとめ",
   "isHome": true
 }


### PR DESCRIPTION
ホームのページタイトルを「accrefs」から「Webアクセシビリティの参考資料まとめ - accrefs」に変更しました。

現状のようにサイトタイトルのみだと、外部（SNS・ブラウザ履歴等）から参照されたときにサイトの内容が伝わりにくいように感じたので、ホームにはサイト説明文から文言をコピペしてみました。

ご確認お願いします！