### PR TITLE
ホームではog:titleにサイトタイトルを使用する

### DIFF
--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -1,4 +1,14 @@
-- const { url, slug } = _universalFilters
+-
+  const { url, slug } = _universalFilters
+
+  let ogTitle
+  if (isHome) {
+    ogTitle = site.title
+  } else if (isTag) {
+    ogTitle = tag.title
+  } else {
+    ogTitle = title
+  }
 
 doctype html
 html(lang=site.lang)
@@ -12,7 +22,7 @@ html(lang=site.lang)
         =`${isTag ? tag.title : title} - ${site.title}`
     meta(name="description" content=site.description)
     meta(name="twitter:card" content="summary")
-    meta(property="og:title" content=isTag ? tag.title : title)
+    meta(property="og:title" content=ogTitle)
     meta(property="og:type" content="website")
     meta(property="og:image" content=`${site.origin}/apple-touch-icon.png`)
     meta(property="og:url" content=`${site.origin}${page.url}`)


### PR DESCRIPTION
ホームのog:titleが「Webアクセシビリティの参考資料まとめ」になっているのを「accrefs」に変更しました。

#41 でog:titleも変更するようにしたんですが、その影響で、ogpが表示される際に同じ文言が続いてしまっていておかしいので修正しました。

<img width="533" alt="TwitterではogpのCardにタイトルとして「Webアクセシビリティの参考資料まとめ」が表示されていて、その下に説明として同じ文言が繰り返されています。" src="https://user-images.githubusercontent.com/11547305/64005852-1d3cfd00-cb4c-11e9-95a9-3c8cde923a52.png">