### PR TITLE
meta descriptionにタグの説明を設定

### DIFF
--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -20,13 +20,13 @@ html(lang=site.lang)
         =`${site.title} - ${title}`
       else
         =`${isTag ? tag.title : title} - ${site.title}`
-    meta(name="description" content=site.description)
+    meta(name="description" content=isTag && tag.content || site.description)
     meta(name="twitter:card" content="summary")
     meta(property="og:title" content=ogTitle)
     meta(property="og:type" content="website")
     meta(property="og:image" content=`${site.origin}/apple-touch-icon.png`)
     meta(property="og:url" content=`${site.origin}${page.url}`)
-    meta(property="og:description" content=site.description)
+    meta(property="og:description" content=isTag && tag.content || site.description)
     meta(property="og:site_name" content=site.title)
     meta(property="og:locale" content=`${site.lang}_${site.region}`)
     link(rel="canonical" href=`${site.origin}${page.url}`)


### PR DESCRIPTION
タグ詳細（`/tags/:tag`）においてタグの説明（`tag.content`）が登録されている場合は、

- `meta[name=description]`
- `meta[property=og:description]`

に設定するよう変更しました。

タグ詳細がSNS等で共有された際にogpとして説明文を表示させたいというのが主な目的です。