### PR TITLE
タグ詳細に非可視ラベルを追加

### DIFF
--- a/src/tag.pug
+++ b/src/tag.pug
@@ -4,17 +4,23 @@ extends /base.pug
 
 block main
   .Stack.-large
-    .Stack.-small
-      h1.Heading
-        span.WithIcon.-tag.-hang.-tighter=tag.title
-      if tag.content
-        p=tag.content
+    div
+      p.VisuallyHidden タグ
+      .Stack.-small
+        h1.Heading
+          span.WithIcon.-tag.-hang.-tighter=tag.title
+        if tag.content
+          p=tag.content
 
-    if collections[tag.title]
-      each reference in collections[tag.title].slice().reverse()
-        article.Stack.-small(id=reference.fileSlug)
-          h2.ItemTitle
-            a.WithIcon.-reference.-hang(href=reference.data.link || null)=reference.data.title
-          !=reference.templateContent
-    else
-      p 参考資料がまだ登録されていません。
+    section#references(aria-labelledby="references-heading")
+      h2#references-heading.VisuallyHidden 参考資料
+
+      if collections[tag.title]
+        .Stack.-large
+          each reference in collections[tag.title].slice().reverse()
+            article.Stack.-small(id=`references:${reference.fileSlug}`)
+              h3.ItemTitle
+                a.WithIcon.-reference.-hang(href=reference.data.link || null)=reference.data.title
+              !=reference.templateContent
+      else
+        p 参考資料がまだ登録されていません。


### PR DESCRIPTION
タグ詳細（`/tags/:tag`）で情報をアイコンだけで区別している箇所があったので非可視ラベルを追加しました。

- `h1`の前に`タグ`を追加
- 参考資料一覧を`参考資料`を見出しとする`section`でラップ

ご確認お願いします！