### PR TITLE
フッターにGitHubリポジトリへのリンクを追加

### DIFF
--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -62,3 +62,5 @@ html(lang=site.lang)
           p #[a(href="https://a11yj.herokuapp.com/") A11YJ Slack]メンバーと有志の協力によって制作・運営されています。
           p
             a(href="/feed.xml" type="application/rss+xml") RSS
+            | ・
+            a(href="https://github.com/a11yj/accrefs") GitHub


### PR DESCRIPTION
「RSS・GitHub」のようになります。ホーム以外にリンクがないので全ページから参照できるようにした意図です。

ご確認よろしくお願いします！