### PR TITLE
参考資料の一覧をファイル名順に並び替え

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,8 @@
 module.exports = (eleventyConfig) => {
   eleventyConfig.addCollection('references', (collection) => {
-    return collection.getFilteredByGlob('src/references/*.md')
+    return collection.getFilteredByGlob('src/references/*.md').sort((a, b) => {
+      return a.inputPath > b.inputPath
+    })
   })
 
   eleventyConfig.addPassthroughCopy('src/assets')


### PR DESCRIPTION
ビルド環境によって参考資料の一覧の並び順に差があったため、明示的にファイル名順に並び替える実装に変更しました。

ご確認お願いします。