### PR TITLE
404ページの追加

### DIFF
--- a/src/404.11tydata.json
+++ b/src/404.11tydata.json
@@ -1,0 +1,4 @@
+{
+  "permalink": "=`${page.fileSlug}.html`",
+  "title": "お探しのページは存在しません"
+}

--- a/src/404.11tydata.json
+++ b/src/404.11tydata.json
@@ -1,4 +1,4 @@
 {
   "permalink": "=`${page.fileSlug}.html`",
-  "title": "お探しのページは存在しません"
+  "title": "このページは存在しません"
 }

--- a/src/404.pug
+++ b/src/404.pug
@@ -7,7 +7,7 @@ block main
 
       p ページのURLが変更されたか、削除された可能性があります。
 
-      p または、もしかするとURLの入力ミスをしているかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
+      p または、もしかするとURLの入力に間違いがあるかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
 
     section#sitemap.Stack(aria-labelledby="sitemap-heading")
       h2#sitemap-heading.Heading サイトマップ

--- a/src/404.pug
+++ b/src/404.pug
@@ -5,9 +5,9 @@ block main
     .Stack
       h1.Heading=title
 
-      p ページのURLが変更されたか、削除された可能性があります。
+      p ページのURLが変更または削除された可能性があります。
 
-      p または、もしかするとURLの入力に間違いがあるかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
+      p あるいは、もしかするとURLの入力に間違いがあるかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
 
     section#sitemap.Stack(aria-labelledby="sitemap-heading")
       h2#sitemap-heading.Heading サイトマップ

--- a/src/404.pug
+++ b/src/404.pug
@@ -1,0 +1,30 @@
+extends /base.pug
+
+block main
+  .Stack.-large
+    .Stack
+      h1.Heading=title
+
+      p ページのURLが変更されたか、削除された可能性があります。
+
+      p または、もしかするとURLの入力ミスをしているかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
+
+    section#sitemap.Stack(aria-labelledby="sitemap-heading")
+      h2#sitemap-heading.Heading サイトマップ
+
+      ul
+        li
+          a(href="/") ホーム
+          ul
+            li
+              a(href="/#tags") タグ
+            li
+              a(href="/#contribution") ウェブサイトに貢献
+        li
+          | タグ
+          ul
+            each tag in tags
+              li
+                a(href=`/tags/${tag.slug}/`)=tag.title
+        li
+          a(href="/references/") 参考資料

--- a/src/404.pug
+++ b/src/404.pug
@@ -5,9 +5,9 @@ block main
     .Stack
       h1.Heading=title
 
-      p ページのURLが変更または削除された可能性があります。
+      p お探しのページは、URLが変更されたか削除されてしまったかもしれません。
 
-      p あるいは、もしかするとURLの入力に間違いがあるかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
+      p または、もしかするとURLの入力に間違いがあるかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
 
     section#sitemap.Stack(aria-labelledby="sitemap-heading")
       h2#sitemap-heading.Heading サイトマップ


### PR DESCRIPTION
エラーメッセージのほか、サイトマップを表示されています。

[Netlifyではファイル名が`404.html`になっていれば自動的に404ページとなる](https://www.netlify.com/docs/redirects/#custom-404)ため、その機能を利用して実装しています。

resolves #47

ご確認お願いします。