### PR TITLE
アイコンに隣接するラベルの折り返し方法を修正

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -133,7 +133,7 @@ video {
 }
 
 .WithIcon {
-  display: inline-flex;
+  display: inline-block;
   padding-left: 2.25em;
   background-repeat: no-repeat;
   background-size: calc(var(--line-height-base) * 1em)


### PR DESCRIPTION
アイコンに隣接するラベルの折り返し方法を修正しました。ラベルとして複数のノードが存在する場合、ノードごとの固まりで横並びになっていたため、通常のテキストと同じように改行させる設定に変更しました。

現状：

![ラベルのボックス内のノードが横並びになっており、ノードの幅に収まらない量のテキストが存在する場合にはそのノード自身のボックスの中で改行してしまっています。](https://user-images.githubusercontent.com/11547305/64090211-02a19880-cd85-11e9-875c-d13298b70a7a.png)

修正後：

![ラベルのボックス内のノードはinlineとしてフラットに並び、ラベルのボックス幅を超える場合は文字単位で改行されています。](https://user-images.githubusercontent.com/11547305/64090213-0503f280-cd85-11e9-860f-64dda44078b1.png)

ご確認お願いします。