### PR TITLE
インラインリストのアイテム同士の区分方法の変更

### DIFF
--- a/src/_includes/base.pug
+++ b/src/_includes/base.pug
@@ -62,7 +62,9 @@ html(lang=site.lang)
       .Center.-andText
         .Stack.-small
           p #[a(href="https://a11yj.herokuapp.com/") A11YJ Slack]メンバーと有志の協力によって制作・運営されています。
-          p
-            a(href="/feed.xml" type="application/rss+xml") RSS
-            | ・
-            a(href="https://github.com/a11yj/accrefs") GitHub
+          .Cluster
+            ul
+              li
+                a(href="/feed.xml" type="application/rss+xml") RSS
+              li
+                a(href="https://github.com/a11yj/accrefs") GitHub

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -91,6 +91,24 @@ video {
   text-align: center;
 }
 
+.Cluster {
+  overflow: hidden;
+}
+
+.Cluster > * {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin: calc(var(--spacer-small) / 2 * -1);
+  padding-left: 0;
+  list-style-type: none;
+}
+
+.Cluster > * > * {
+  margin: calc(var(--spacer-small) / 2);
+}
+
 .VisuallyHidden {
   position: absolute !important;
   overflow: hidden !important;

--- a/src/references.pug
+++ b/src/references.pug
@@ -15,5 +15,5 @@ block main
             span.WithIcon.-tag
               each tag, index in reference.data.tags
                 if index
-                  | ・
+                  | ／
                 a(href=`/tags/${tags.find(t => t.title === tag).slug}/`)=tag


### PR DESCRIPTION
ひとつの参考資料にタグが複数存在する場合は中黒で区分していましたが、タグ自体も中黒を含む場合があり混合の可能性があるため、全角スラッシュで区分するよう変更しました。タグ同士を余白で区分すると、2つ目以降のリンクがアイコンから離れているために、タグであると理解しにくいと感じたためこのような判断にしています。

現状：

![「タグアイコン　公式仕様および和訳・WAI-ARIA」のように表示されます。](https://user-images.githubusercontent.com/11547305/64091657-2b795c00-cd8c-11e9-9983-533eaff787b9.png)

修正後：

![「タグアイコン　公式仕様および和訳／WAI-ARIA」のように表示されます。](https://user-images.githubusercontent.com/11547305/64091666-3633f100-cd8c-11e9-9974-fd54f706aad5.png)

---

また、フッター内のリンク群も中黒で区分していましたが、余白によって区分するよう変更しました。タグの区分方法とルールを一貫させるために中黒を使用していましたが、フッターであるという文脈上、余白で区分した方が自然に思えるため変更しました。

現状：

![「RSS・GitHub」のように表示されます。](https://user-images.githubusercontent.com/11547305/64091677-45b33a00-cd8c-11e9-953f-e46658283eba.png)

修正後：

![「RSS　GitHub」のように表示されます。](https://user-images.githubusercontent.com/11547305/64091696-52d02900-cd8c-11e9-8a9f-930ac3fe809a.png)

---

ご確認お願いします。