### PR TITLE
[スタイル] 見出し2相当のセクション同士の分割方法の見直し

### DIFF
--- a/src/404.pug
+++ b/src/404.pug
@@ -9,22 +9,23 @@ block main
 
       p または、もしかするとURLの入力に間違いがあるかもしれないので、単純なスペルミスなどをしていないか確認してみてください。
 
-    section#sitemap.Stack(aria-labelledby="sitemap-heading")
-      h2#sitemap-heading.Heading サイトマップ
+    .Stack.-xlarge
+      section#sitemap.Stack(aria-labelledby="sitemap-heading")
+        h2#sitemap-heading.Heading サイトマップ
 
-      ul
-        li
-          a(href="/") ホーム
-          ul
-            li
-              a(href="/#tags") タグ
-            li
-              a(href="/#contribution") ウェブサイトに貢献
-        li
-          | タグ
-          ul
-            each tag in tags
+        ul
+          li
+            a(href="/") ホーム
+            ul
               li
-                a(href=`/tags/${tag.slug}/`)=tag.title
-        li
-          a(href="/references/") 参考資料
+                a(href="/#tags") タグ
+              li
+                a(href="/#contribution") ウェブサイトに貢献
+          li
+            | タグ
+            ul
+              each tag in tags
+                li
+                  a(href=`/tags/${tag.slug}/`)=tag.title
+          li
+            a(href="/references/") 参考資料

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -8,6 +8,9 @@
   --line-height-base: var(--ratio);
   --line-height-small: calc(var(--line-height-base) * 0.8);
   --spacer-base: calc(var(--ratio) * var(--font-size-base));
+  --spacer-xlarge: calc(
+    var(--spacer-base) * var(--ratio) * var(--ratio) * var(--ratio)
+  );
   --spacer-large: calc(var(--spacer-base) * var(--ratio) * var(--ratio));
   --spacer-small: calc(var(--spacer-base) / var(--ratio));
   --max-width-content: 40rem;
@@ -67,6 +70,10 @@ video {
 
 .Stack > * + * {
   margin-top: var(--spacer-base);
+}
+
+.Stack.-xlarge > * + * {
+  margin-top: var(--spacer-xlarge);
 }
 
 .Stack.-large > * + * {

--- a/src/index.pug
+++ b/src/index.pug
@@ -3,7 +3,7 @@ extends /base.pug
 block main
   h1.VisuallyHidden=`${site.title} ホーム`
 
-  .Stack.-large
+  .Stack.-xlarge
     section#tags.Stack.-large(aria-labelledby="tags-heading")
       h2#tags-heading.Heading タグ
 
@@ -16,8 +16,6 @@ block main
 
       p
         a.WithIcon.-reference(href="/references/") すべての参考資料
-
-    .Divider
 
     section#contribution.Stack(aria-labelledby="contribution-heading")
       h2#contribution-heading.Heading ウェブサイトに貢献


### PR DESCRIPTION
ホームページにおいて、見出し2相当のセクション同士をボーダーで分割していたのを、より大きな余白を追加することによって分割するよう変更しました。

今のところ問題にはなっていませんが、将来的に、

- 見出し1が可視状態かつ
- 見出し2相当のセクションが複数存在する

ページが出現した場合、現状のホームページのような分割方法を取ってしまうと、並び順が最初の見出し2相当のセクションのみ見出し1とグルーピングされているように見えてしまうため、代わりに多めの余白を取ることで特別な意味を感じさせないようにした意図です。

ご確認お願いします。