### PR TITLE
[スタイル] CSS内のタイポの修正

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -26,8 +26,8 @@ html {
 
 body {
   margin: 0;
-  color: hsl(0, 0%, 0%, 0.87);
-  background-color: hsla(0, 0%, 94%);
+  color: hsla(0, 0%, 0%, 0.87);
+  background-color: hsl(0, 0%, 94%);
 }
 
 h1,


### PR DESCRIPTION
`hsl()`と`hsla()`をタイポしていたので修正しました。多くのブラウザではこれでも意図した値を適用できているらしく、見落としていました。

ご確認お願いします。