### PR TITLE
[スタイル] 訪問済みリンクのカラーコントラストを改善

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -59,7 +59,7 @@ a:any-link:active {
 }
 
 a:visited {
-  color: hsl(0, 0%, 34%);
+  color: hsl(0, 0%, 31%);
 }
 
 img,
@@ -226,8 +226,4 @@ h2.Heading {
   padding-top: var(--spacer-base);
   padding-bottom: var(--spacer-base);
   font-size: var(--font-size-small);
-}
-
-.SiteFooter a:visited {
-  color: hsl(0, 0%, 31%);
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -59,7 +59,7 @@ a:any-link:active {
 }
 
 a:visited {
-  color: hsl(0, 0%, 40%);
+  color: hsl(0, 0%, 34%);
 }
 
 img,
@@ -226,4 +226,8 @@ h2.Heading {
   padding-top: var(--spacer-base);
   padding-bottom: var(--spacer-base);
   font-size: var(--font-size-small);
+}
+
+.SiteFooter a:visited {
+  color: hsl(0, 0%, 31%);
 }


### PR DESCRIPTION
サイト全体の訪問済みリンクのカラーコントラスト比がAAA準拠になるよう変更しました。

`.Main`:

|        | 背景色          | 訪問済みリンク色 | コントラスト比 |
|--------|-----------------|------------------|----------------|
| 変更前 | `hsl(0, 0%, 99%)` | `hsl(0, 0%, 40%)`  | 5.60           |
| 変更後 | `hsl(0, 0%, 99%)` | `hsl(0, 0%, 31%)`  | **7.98**           |

`.SiteFooter`:

|        | 背景色          | 訪問済みリンク色      | コントラスト比 |
|--------|-----------------|-----------------------|----------------|
| 変更前 | `hsl(0, 0%, 94%)` | `hsl(0, 0%, 40%)`       | 5.04           |
| 変更後 | `hsl(0, 0%, 94%)` | `hsl(0, 0%, 31%)` | **7.18**          |

ご確認お願いします。