### PR TITLE
[WAI-ARIA] <article>要素にアクセシブルな名前を提供

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -8,8 +8,11 @@ block main
       h2#tags-heading.Heading タグ
 
       each tag in tags
-        article.Stack.-small(id=`tags:${tag.slug}`)
-          h3.ItemTitle
+        article.Stack.-small(
+          id=`tags:${tag.slug}`
+          aria-labelledby=`tags:${tag.slug}-heading`
+        )
+          h3.ItemTitle(id=`tags:${tag.slug}-heading`)
             a.WithIcon.-tag.-hang(href=`/tags/${tag.slug}/`)=tag.title
           if tag.content
             p=tag.content

--- a/src/references.pug
+++ b/src/references.pug
@@ -5,8 +5,11 @@ block main
     h1.Heading=title
 
     each reference in collections.references.slice().reverse()
-      article.Stack.-small(id=reference.fileSlug)
-        h2.ItemTitle
+      article.Stack.-small(
+        id=reference.fileSlug
+        aria-labelledby=`${reference.fileSlug}-heading`
+      )
+        h2.ItemTitle(id=`${reference.fileSlug}-heading`)
           a.WithIcon.-reference.-hang(href=reference.data.link)=reference.data.title
         !=reference.templateContent
         footer

--- a/src/tag.pug
+++ b/src/tag.pug
@@ -18,8 +18,11 @@ block main
       if collections[tag.title]
         .Stack.-large
           each reference in collections[tag.title].slice().reverse()
-            article.Stack.-small(id=`references:${reference.fileSlug}`)
-              h3.ItemTitle
+            article.Stack.-small(
+              id=`references:${reference.fileSlug}`
+              aria-labelledby=`references:${reference.fileSlug}-heading`
+            )
+              h3.ItemTitle(id=`references:${reference.fileSlug}-heading`)
                 a.WithIcon.-reference.-hang(href=reference.data.link)=reference.data.title
               !=reference.templateContent
       else


### PR DESCRIPTION
サイト内すべての`<article>`要素にアクセシブルな名前を提供しました。`aria-labelledby`によって各要素内の見出しを参照しています。

[article roleにはアクセシブルな名前の提供が推奨されている](https://www.w3.org/TR/wai-aria-practices-1.1/#naming_role_guidance)ためです。

ご確認お願いします。