### PR TITLE
年別リストを追加する

### DIFF
--- a/src/assets/icons.svg
+++ b/src/assets/icons.svg
@@ -19,4 +19,10 @@
     <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"/><path fill="none" d="M0 0h24v24H0z"/>
   </symbol>
   <use id="back" href="#_back" fill="hsla(0, 0%, 0%, 0.4)"/>
+
+  <symbol id="_year">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"/>
+  </symbol>
+  <use id="year" href="#_year" fill="hsla(0, 0%, 0%, 0.4)"/>
 </svg>

--- a/src/assets/icons.svg
+++ b/src/assets/icons.svg
@@ -6,17 +6,20 @@
   </style>
 
   <symbol id="_reference">
-    <path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
   </symbol>
   <use id="reference" href="#_reference" fill="hsla(0, 0%, 0%, 0.4)"/>
 
   <symbol id="_tag">
-    <path d="M0 0h24v24H0z" fill="none"></path><path d="M17.63 5.84C17.27 5.33 16.67 5 16 5L5 5.01C3.9 5.01 3 5.9 3 7v10c0 1.1.9 1.99 2 1.99L16 19c.67 0 1.27-.33 1.63-.84L22 12l-4.37-6.16z"></path>
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M17.63 5.84C17.27 5.33 16.67 5 16 5L5 5.01C3.9 5.01 3 5.9 3 7v10c0 1.1.9 1.99 2 1.99L16 19c.67 0 1.27-.33 1.63-.84L22 12l-4.37-6.16z"/>
   </symbol>
   <use id="tag" href="#_tag" fill="hsla(0, 0%, 0%, 0.4)"/>
 
   <symbol id="_back">
-    <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"/><path fill="none" d="M0 0h24v24H0z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"/>
   </symbol>
   <use id="back" href="#_back" fill="hsla(0, 0%, 0%, 0.4)"/>
 

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -186,6 +186,10 @@ video {
   background-image: url("/assets/icons.svg#back");
 }
 
+.WithIcon.-year {
+  background-image: url("/assets/icons.svg#year");
+}
+
 @media (min-width: 60em) {
   .WithIcon.-hang {
     margin-left: -2.25em;

--- a/src/references/00002.md
+++ b/src/references/00002.md
@@ -3,4 +3,5 @@ title: "<img>要素のalt属性の入れかた — Website Usability Info"
 tags:
   - "alt（代替テキスト）"
 link: "https://website-usability.info/2007/01/entry_070120.html"
+year: 2007
 ---

--- a/src/references/00003.md
+++ b/src/references/00003.md
@@ -3,6 +3,7 @@ title: "@mjmj さんのポスター「Web Accessibility for Designers」"
 tags:
   - "ビジュアルデザイン"
 link: "https://twitter.com/mjmjsachi/status/959607620733562880"
+year: 2018
 ---
 
 [A4 版 PDF](https://www.dropbox.com/s/11kq1shbiaxpfdw/a11y_4designers_A4.pdf)

--- a/src/references/00005.md
+++ b/src/references/00005.md
@@ -3,6 +3,7 @@ title: "AI を使った画像解析による代替テキスト提案機能「Alt
 tags:
   - "alt（代替テキスト）"
 link: "https://www.powercms.jp/blog/2018/05/powercms5-functions-altsuggest.html"
+year: 2018
 ---
 
 すでに実用化されていた!

--- a/src/templates/_base.pug
+++ b/src/templates/_base.pug
@@ -3,12 +3,15 @@
   const isHome = type === 'home'
   const isNotFound = type === '404'
   const isTag = type === 'tag'
+  const isYear = type === 'year'
   const metaTitle = isReferences
     ? `すべての参考資料 - ${SITE_NAME}`
     : isNotFound
     ? `このページは存在しません - ${SITE_NAME}`
     : isTag
     ? `${tag.title} - ${SITE_NAME}`
+    : isYear
+    ? `${year} - ${SITE_NAME}`
     : SITE_NAME
   const ogTitle = isReferences
     ? `すべての参考資料`
@@ -16,6 +19,8 @@
     ? `このページは存在しません`
     : isTag
     ? `${tag.title}`
+    : isYear
+    ? `${year}年`
     : SITE_NAME
   const description = isReferences
     ? "accrefs が紹介している参考資料の一覧"
@@ -30,6 +35,8 @@
     ? `${SITE_ORIGIN}/404.html`
     : isTag
     ? `${SITE_ORIGIN}/tags/${tag.slug}.html`
+    : isYear
+    ? `${SITE_ORIGIN}/years/${year}.html`
     : SITE_ORIGIN
 
 doctype html

--- a/src/templates/_script.pug
+++ b/src/templates/_script.pug
@@ -4,15 +4,16 @@ script.
     const $Search = document.querySelector("#Search");
     if (!$Search) return;
     let debounceTimer = 0;
-    const refs = Array.from(document.querySelectorAll("article[id^=reference]"));
+    const refs = [...document.querySelectorAll("article[id^=reference]")];
     const models = refs.map((ref) => ({
       id: ref.id,
       title: ref.querySelector(".-reference").innerText.toLowerCase(),
       link: ref.querySelector(".-reference").href.toLowerCase(),
+      year: ref.dataset.year,
       content: ref.children[2] ? ref.children[1].innerText.toLowerCase() : null,
     }));
 
-    const getMatchedIds = (lc_query) => models.filter(({ title, link, content }) => RegExp(lc_query).test(title) || RegExp(lc_query).test(link) || RegExp(lc_query).test(content)).map(({ id }) => id);
+    const getMatchedIds = (lc_query) => models.filter(({ title, link, year, content }) => RegExp(lc_query).test(title) || RegExp(lc_query).test(link) || RegExp(lc_query).test(year) || RegExp(lc_query).test(content)).map(({ id }) => id);
 
     const search = (query) => {
       const ids = getMatchedIds(query.toLowerCase());

--- a/src/templates/home.pug
+++ b/src/templates/home.pug
@@ -28,9 +28,11 @@ block main
     section#years.Stack
       .Cluster.-justify-start.WithIcon.-year.-hang
         ul
-          each year in years
+          each year, index in years
             li
               a(href=`/years/${year}/`)= year
+              if index !== years.length - 1
+                | ,
 
     section#contribution.Stack(aria-labelledby="contribution-heading")
       h2#contribution-heading.Heading ウェブサイトに貢献

--- a/src/templates/home.pug
+++ b/src/templates/home.pug
@@ -25,6 +25,13 @@ block main
       p
         a.WithIcon.-reference.-hang(href="/references/") すべての参考資料
 
+    section#years.Stack
+      .Cluster.-justify-start
+        ul
+          each year in years
+            li
+              a(href=`/years/${year}/`)= year
+
     section#contribution.Stack(aria-labelledby="contribution-heading")
       h2#contribution-heading.Heading ウェブサイトに貢献
 

--- a/src/templates/home.pug
+++ b/src/templates/home.pug
@@ -26,7 +26,7 @@ block main
         a.WithIcon.-reference.-hang(href="/references/") すべての参考資料
 
     section#years.Stack
-      .Cluster.-justify-start
+      .Cluster.-justify-start.WithIcon.-year.-hang
         ul
           each year in years
             li

--- a/src/templates/references.pug
+++ b/src/templates/references.pug
@@ -15,7 +15,8 @@ block main
     each reference in references.slice().reverse()
       article.Stack.-small(
         id=`reference:${reference.id}`,
-        aria-labelledby=`reference:${reference.id}-heading`
+        aria-labelledby=`reference:${reference.id}-heading`,
+        data-year=`${reference.data.year}`
       )
         h2.ItemTitle(id=`reference:${reference.id}-heading`)
           a.WithIcon.-reference.-hang(href=reference.data.link)= reference.data.title

--- a/src/templates/tag.pug
+++ b/src/templates/tag.pug
@@ -18,7 +18,8 @@ block main
           each reference in collection.slice().reverse()
             article.Stack.-small(
               id=`references:${reference.id}`,
-              aria-labelledby=`references:${reference.id}-heading`
+              aria-labelledby=`references:${reference.id}-heading`,
+              data-year=`${reference.data.year}`
             )
               h3.ItemTitle(id=`references:${reference.id}-heading`)
                 a.WithIcon.-reference.-hang(href=reference.data.link)= reference.data.title

--- a/src/templates/year.pug
+++ b/src/templates/year.pug
@@ -1,0 +1,25 @@
+extends _base
+
+block main
+  .Stack.-large
+    div
+      .Stack.-small
+        h1.Heading= ogTitle
+        p #{ year }年に公開、またはその年の出来事に言及している参考資料一覧です。
+
+    section#references(aria-labelledby="references-heading")
+      h2#references-heading.Invisible 参考資料
+
+      if collection.length > 0
+        .Stack.-large
+          each reference in collection.slice().reverse()
+            article.Stack.-small(
+              id=`references:${reference.id}`,
+              aria-labelledby=`references:${reference.id}-heading`,
+              data-year=`${reference.data.year}`
+            )
+              h3.ItemTitle(id=`references:${reference.id}-heading`)
+                a.WithIcon.-reference.-hang(href=reference.data.link)= reference.data.title
+              != reference.marked
+      else
+        p 参考資料がまだ登録されていません。

--- a/task/database.mjs
+++ b/task/database.mjs
@@ -13,7 +13,9 @@ export const database = (matter) => ({
   ),
   years: [
     ...new Set(
-      matter.filter((item) => !item.data.ignore).map((ref) => ref.data.year)
+      matter.flatMap((item) =>
+        !item.data.ignore && item.data.year ? item.data.year : []
+      )
     ),
   ],
   ...CONSTANTS,

--- a/task/database.mjs
+++ b/task/database.mjs
@@ -11,5 +11,10 @@ export const database = (matter) => ({
         }
       : []
   ),
+  years: [
+    ...new Set(
+      matter.filter((item) => !item.data.ignore).map((ref) => ref.data.year)
+    ),
+  ],
   ...CONSTANTS,
 });

--- a/task/lint.mjs
+++ b/task/lint.mjs
@@ -162,7 +162,7 @@ const validateReferences = (references, tags) => {
             `\`${reference.filepath}\`の\`${key}\`は数値にしてください。`
           );
         }
-        if (/\d{4}/.test(value)) {
+        if (!/\d{4}/.test(value)) {
           throw new TypeError(
             `\`${reference.filepath}\`の\`${key}\`は4桁にしてください。`
           );


### PR DESCRIPTION
ref: #118 

資料数が膨大になってきているので、わかる範囲で資料の公開年（もしくは対象の言及年）別に一覧したい。

年ごとのリストは `/years/{YYYY}/index.html` とする。

このPRでは確認のため3つのmdファイルのYAMLブロックに `year` をつけていますが、最終的には全てのmdに適用します。

例外として公開年に依存しないLivingStandardな公式仕様やチェックツールなどは `year` を付与しないので年別のリストに抽出されませんが、タグ別や絞り込みで拾える数だと想定されるので良しとします。

| ホーム | 年ごと |
|:---:|:---:|
| ![_____3000_](https://github.com/a11yj/accrefs/assets/710216/ce89a20c-5470-4f5f-a334-6e3e04c6840f) | ![__ _3000_years_2018_](https://github.com/a11yj/accrefs/assets/710216/78379423-effe-4547-8734-babfce098af1) |
